### PR TITLE
Implement Byte-Aware Chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,32 @@ For multi-byte characters, `charLengthMask` allows awareness of multi-byte glyph
 const runner = '🏃🏽‍♀️';
 const outDefault = chunk(runner+runner+runner, 4);
 /* [ '🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️' ] */
-const outZero = chunk(runner+runner+runner, 4, 0);
+const outZero = chunk(runner+runner+runner, 4, { charLengthMask: 0 });
 /* [ '🏃🏽‍♀️', '🏃🏽‍♀️', '🏃🏽‍♀️' ] */
-const outTwo = chunk(runner+runner+runner, 4, 2);
+const outTwo = chunk(runner+runner+runner, 4, { charLengthMask: 2 });
 /* [ '🏃🏽‍♀️🏃🏽‍♀️', '🏃🏽‍♀️' ] */
+// FLAG + RAINBOW
+// 2 each as length, 4 each as TextEncoder
+// 4 as length, 8 as TextEncoder
+// Node v14.5.0 does not provide TextEncoder natively.
+const flags = '🏳️‍🌈🏳️‍🌈';
+// will fail if your environment doesn't already have TextEncoder
+chunk(flags, 8, { charLengthMask: 0, charLengthType: 'TextEncoder' });
+// [ '🏳️‍🌈', '🏳️‍🌈' ]
+chunk(flags, 4, {
+  charLengthMask: 0,
+  charLengthType: 'TextEncoder',
+  textEncoder: new TextEncoder(),
+})
+// [ '🏳️‍🌈', '🏳️‍🌈' ]
+chunk(flags, 999, {
+  charLengthMask: 0,
+  charLengthType: 'TextEncoder',
+  textEncoder: {
+    encode: () => ({ length: 999 }),
+  },
+})
+// [ '🏳️‍🌈', '🏳️‍🌈' ]
 ```
 
 ## Usage in Algolia context

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ npm install chunk-text
 
 ## Usage
 
+All number values are parsed according to `Number.parseInt`.
+
 ``` javascript
 var chunk = require('chunk-text');
 ```
@@ -39,6 +41,35 @@ ensure the resulting text chunks have at maximum a length of `chunkSize`.
 ``` javascript
 var out = chunk('hello world', 4);
 /* ['hell', 'o', 'worl', 'd'] */
+```
+
+#### chunk(text, chunkSize, chunkType);
+
+Chunks the `text` string into an array of strings that each have a maximum length of `chunkSize`, as determined by `chunkType`.
+
+The default behavior if `chunkType` is excluded is equal to `chunkType=-1`.
+
+For single-byte characters, `chunkType` never changes the results.
+
+For multi-byte characters, `chunkType` allows awareness of multi-byte glyphs according to the following table:
+
+| `chunkType` | result                                                                                                                                                                                          |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -1          | - same as default, same as `chunkType=1`<br />- each character counts as 1 towards length                                                                                                         |
+| 0           | - each character counts as the number of bytes it contains                                                                                                                                      |
+| >0          | - each character counts as the number of bytes it contains, up to a limit of `chunkType=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `chunkType=2` |
+
+``` javascript
+// one woman runner emoji with a colour is seven bytes, or five characters
+// RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+// (actually encodes to 17)
+const runner = '🏃🏽‍♀️';
+const outDefault = chunk(runner+runner+runner, 4);
+/* [ '🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️' ] */
+const outZero = chunk(runner+runner+runner, 4, 0);
+/* [ '🏃🏽‍♀️', '🏃🏽‍♀️', '🏃🏽‍♀️' ] */
+const outTwo = chunk(runner+runner+runner, 4, 2);
+/* [ '🏃🏽‍♀️🏃🏽‍♀️', '🏃🏽‍♀️' ] */
 ```
 
 ## Usage in Algolia context

--- a/README.md
+++ b/README.md
@@ -43,21 +43,21 @@ var out = chunk('hello world', 4);
 /* ['hell', 'o', 'worl', 'd'] */
 ```
 
-#### chunk(text, chunkSize, chunkType);
+#### chunk(text, chunkSize, charLengthMask);
 
-Chunks the `text` string into an array of strings that each have a maximum length of `chunkSize`, as determined by `chunkType`.
+Chunks the `text` string into an array of strings that each have a maximum length of `chunkSize`, as determined by `charLengthMask`.
 
-The default behavior if `chunkType` is excluded is equal to `chunkType=-1`.
+The default behavior if `charLengthMask` is excluded is equal to `charLengthMask=-1`.
 
-For single-byte characters, `chunkType` never changes the results.
+For single-byte characters, `charLengthMask` never changes the results.
 
-For multi-byte characters, `chunkType` allows awareness of multi-byte glyphs according to the following table:
+For multi-byte characters, `charLengthMask` allows awareness of multi-byte glyphs according to the following table:
 
-| `chunkType` | result                                                                                                                                                                                          |
+| `charLengthMask` | result                                                                                                                                                                                          |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -1          | - same as default, same as `chunkType=1`<br />- each character counts as 1 towards length                                                                                                         |
+| -1          | - same as default, same as `charLengthMask=1`<br />- each character counts as 1 towards length                                                                                                         |
 | 0           | - each character counts as the number of bytes it contains                                                                                                                                      |
-| >0          | - each character counts as the number of bytes it contains, up to a limit of `chunkType=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `chunkType=2` |
+| >0          | - each character counts as the number of bytes it contains, up to a limit of `charLengthMask=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `charLengthMask=2` |
 
 ``` javascript
 // one woman runner emoji with a colour is seven bytes, or five characters

--- a/README.md
+++ b/README.md
@@ -63,7 +63,21 @@ You can also substitute from the default `chunkOptions.charLengthType` property 
 
 This enables you to pass any object to `chunkOptions.textEncoder` which matches the signature, `chunkOptions.textEncoder.encode(text).length`
 
-If your environment natively contains the `TextEncoder` class, one can rely on `new TextEncoder()` in order to use this `chunkOptions.charLengthType`.
+If your environment natively contains the `TextEncoder` prototype and `chunkOptions.textEncoder` isn't provided,
+
+the module attempts `new TextEncoder()` in order to use this `chunkOptions.charLengthType`.
+
+If
+
+- `chunkOptions.charLengthType` is set to `TextEncoder`.
+- `chunkOptions.textEncoder` isn't provided.
+- `TextEncoder` prototype isn't provided by the environment.
+
+Then
+
+- `ReferenceError` will occur.
+
+End If
 
 ``` javascript
 // one woman runner emoji with a colour is seven bytes, or five characters
@@ -86,10 +100,10 @@ const outTwo = chunk(runner+runner+runner, 4, { charLengthMask: 2 });
 // Node v14.5.0 does not provide TextEncoder natively.
 const flags = '🏳️‍🌈🏳️‍🌈';
 
-// \/ will fail if your environment doesn't already have TextEncoder \/
+// \/ will fail if your environment doesn't already have TextEncoder prototype \/
 chunk(flags, 8, { charLengthMask: 0, charLengthType: 'TextEncoder' });
 // [ '🏳️‍🌈', '🏳️‍🌈' ]
-// /\ will fail if your environment doesn't already have TextEncoder /\
+// /\ will fail if your environment doesn't already have TextEncoder prototype /\
 
 chunk(flags, 4, {
   charLengthMask: 0,

--- a/README.md
+++ b/README.md
@@ -64,26 +64,34 @@ For multi-byte characters, `charLengthMask` allows awareness of multi-byte glyph
 // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
 // (actually encodes to 17)
 const runner = '🏃🏽‍♀️';
+
 const outDefault = chunk(runner+runner+runner, 4);
 /* [ '🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️' ] */
+
 const outZero = chunk(runner+runner+runner, 4, { charLengthMask: 0 });
 /* [ '🏃🏽‍♀️', '🏃🏽‍♀️', '🏃🏽‍♀️' ] */
+
 const outTwo = chunk(runner+runner+runner, 4, { charLengthMask: 2 });
 /* [ '🏃🏽‍♀️🏃🏽‍♀️', '🏃🏽‍♀️' ] */
+
 // FLAG + RAINBOW
 // 2 each as length, 4 each as TextEncoder
 // 4 as length, 8 as TextEncoder
 // Node v14.5.0 does not provide TextEncoder natively.
 const flags = '🏳️‍🌈🏳️‍🌈';
-// will fail if your environment doesn't already have TextEncoder
+
+// \/ will fail if your environment doesn't already have TextEncoder \/
 chunk(flags, 8, { charLengthMask: 0, charLengthType: 'TextEncoder' });
 // [ '🏳️‍🌈', '🏳️‍🌈' ]
+// /\ will fail if your environment doesn't already have TextEncoder /\
+
 chunk(flags, 4, {
   charLengthMask: 0,
   charLengthType: 'TextEncoder',
   textEncoder: new TextEncoder(),
 })
 // [ '🏳️‍🌈', '🏳️‍🌈' ]
+
 chunk(flags, 999, {
   charLengthMask: 0,
   charLengthType: 'TextEncoder',
@@ -107,7 +115,6 @@ The text chunks can then be [distributed over multiple records](https://www.algo
 Here is an example of how to split an existing record into several ones:
 
 ``` javascript
-
 var chunk = require('chunk-text');
 var record = {
   post_id: 100,
@@ -119,5 +126,4 @@ var records = [];
 chunks.forEach(function(content) {
   records.push(Object.assign({}, record, {content: content}));
 });
-
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For multi-byte characters, `chunkOptions.charLengthMask` allows awareness of mul
 | 0           | - each character counts as the number of bytes it contains                                                                                                                                      |
 | >0          | - each character counts as the number of bytes it contains, up to a limit of `chunkOptions.charLengthMask=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `chunkOptions.charLengthMask=2` |
 
-You can also substitute from the default `chunkOptions.charLengthType` property from `length` to `TextEncoder`.
+You can also substitute from the default `chunkOptions.charLengthType` property of `length` to `TextEncoder`.
 
 This enables you to pass any object to `chunkOptions.textEncoder` which matches the signature, `chunkOptions.textEncoder.encode(text).length`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Chunk text
+Chunk Text
 ===
 
 > chunk/split a string by length without cutting/truncating words.
@@ -43,21 +43,27 @@ var out = chunk('hello world', 4);
 /* ['hell', 'o', 'worl', 'd'] */
 ```
 
-#### chunk(text, chunkSize, charLengthMask);
+#### chunk(text, chunkSize, chunkOptions);
 
-Chunks the `text` string into an array of strings that each have a maximum length of `chunkSize`, as determined by `charLengthMask`.
+Chunks the `text` string into an array of strings that each have a maximum length of `chunkSize`, as determined by `chunkOptions.charLengthMask`.
 
-The default behavior if `charLengthMask` is excluded is equal to `charLengthMask=-1`.
+The default behavior if `chunkOptions.charLengthMask` is excluded is equal to `chunkOptions.charLengthMask=-1`.
 
-For single-byte characters, `charLengthMask` never changes the results.
+For single-byte characters, `chunkOptions.charLengthMask` never changes the results.
 
-For multi-byte characters, `charLengthMask` allows awareness of multi-byte glyphs according to the following table:
+For multi-byte characters, `chunkOptions.charLengthMask` allows awareness of multi-byte glyphs according to the following table:
 
-| `charLengthMask` | result                                                                                                                                                                                          |
+| `chunkOptions.charLengthMask` | result                                                                                                                                                                                          |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -1          | - same as default, same as `charLengthMask=1`<br />- each character counts as 1 towards length                                                                                                         |
+| -1          | - same as default, same as `chunkOptions.charLengthMask=1`<br />- each character counts as 1 towards length                                                                                                         |
 | 0           | - each character counts as the number of bytes it contains                                                                                                                                      |
-| >0          | - each character counts as the number of bytes it contains, up to a limit of `charLengthMask=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `charLengthMask=2` |
+| >0          | - each character counts as the number of bytes it contains, up to a limit of `chunkOptions.charLengthMask=N`<br />- a 7-byte ZWJ emoji such as runningPerson+ZWJ+femaleSymbol (🏃🏽‍♀️) counts as 2, when `chunkOptions.charLengthMask=2` |
+
+You can also substitute from the default `chunkOptions.charLengthType` property from `length` to `TextEncoder`.
+
+This enables you to pass any object to `chunkOptions.textEncoder` which matches the signature, `chunkOptions.textEncoder.encode(text).length`
+
+If your environment natively contains the `TextEncoder` class, one can rely on `new TextEncoder()` in order to use this `chunkOptions.charLengthType`.
 
 ``` javascript
 // one woman runner emoji with a colour is seven bytes, or five characters

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const chunk = require('../dist/index.js');
+console.log(chunk(process.argv[2], Number.parseInt(process.argv[3], 10), typeof process.argv[4] !== 'undefined' && process.argv[4] !== null && process.argv[4] !== '' ? JSON.parse(process.argv[4]) : ''));

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-prettier": "^2.1.2",
-    "fast-text-encoding": "^1.0.3",
     "fastestsmallesttextencoderdecoder-encodeinto": "^1.0.22",
     "jest": "^20.0.4",
     "prettier": "^1.4.4"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "chunk-text",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "🔪 chunk/split a string by length without cutting/truncating words.",
-  "main": "dist/index.js",
   "repository": "https://github.com/algolia/chunk-text",
   "author": "Raymond RUTJES <raymond.rutjes@algolia.com>",
   "license": "MIT",
@@ -28,6 +27,7 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-prettier": "^2.1.2",
+    "fast-text-encoding": "^1.0.3",
     "jest": "^20.0.4",
     "prettier": "^1.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-prettier": "^2.1.2",
     "fast-text-encoding": "^1.0.3",
+    "fastestsmallesttextencoderdecoder-encodeinto": "^1.0.22",
     "jest": "^20.0.4",
     "prettier": "^1.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chunk-text",
   "version": "1.1.0",
   "description": "🔪 chunk/split a string by length without cutting/truncating words.",
+  "main": "dist/index.js",
   "repository": "https://github.com/algolia/chunk-text",
   "author": "Raymond RUTJES <raymond.rutjes@algolia.com>",
   "license": "MIT",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,4 +1,5 @@
 import chunk from '../index';
+import 'fast-text-encoding'; // Required for TextEncoder support in jest.
 
 it('should throw an error if no text is provided or invalid type.', () => {
   expect(() => {
@@ -25,6 +26,131 @@ it('should throw an error if no size is provided or invalid type.', () => {
   );
 });
 
+it("should throw if 'type' argument's type or value is invalid.", () => {
+  expect(() => {
+    chunk('hello world', 1, 'one');
+  }).toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, -2.001);
+  }).toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, -2);
+  }).toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, 3);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, '3');
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+});
+
+it("should not throw if 'type' type and value are missing or valid.", () => {
+  expect(() => {
+    chunk('hello world', 1, '');
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, null);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, undefined);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, -1.999);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, -0.001);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, 0.0);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, 1.0);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, new Number.BigInt(2.0));
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, 2.999);
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, '2.99999 years');
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, '2');
+  }).not.toThrow(
+    new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    )
+  );
+});
+
 it('should return an array of strings.', () => {
   const pieces = chunk('hello world', 5);
   expect(pieces).toEqual(['hello', 'world']);
@@ -40,14 +166,351 @@ it('should truncate a word if longer than size', () => {
   expect(pieces).toEqual(['hell', 'o', 'you']);
 });
 
-it('should count double width characters as single characters', () => {
+it('should count multi-byte characters as single characters by default', () => {
+  // each of these characters is two bytes
+  const chineseTextA = '𤻪';
+  const chineseTextB = '𬜬';
+  const chineseTextC = '𬜯';
+  const chineseText = chineseTextA + chineseTextB + chineseTextC;
+  expect(chunk(chineseText, 2)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 1)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+
+  // each of these characters is two bytes
+  const fourCheese = '🧀🧀🧀🧀';
+  const camembert = `${fourCheese} ${fourCheese}`;
+  expect(chunk(camembert, 4)).toEqual([fourCheese, fourCheese]);
+
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  const runner = '🏃🏽‍♀️';
+  expect(
+    chunk(runner + runner + runner + runner + runner + runner + runner, 3)
+  ).toEqual([runner + runner + runner, runner + runner + runner, runner]);
+});
+
+it('should count all characters as single characters using chunkType -1 or 1 values', () => {
+  // each of these characters is two bytes
+  const chineseTextA = '𤻪';
+  const chineseTextB = '𬜬';
+  const chineseTextC = '𬜯';
+  const chineseText = chineseTextA + chineseTextB + chineseTextC;
+  expect(chunk(chineseText, 2, -1)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 1, -1)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 2, 1)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 1, 1)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+
+  // each of these characters is two bytes
+  const fourCheese = '🧀🧀🧀🧀';
+  const camembert = `${fourCheese} ${fourCheese}`;
+  expect(chunk(camembert, 4, -1)).toEqual([fourCheese, fourCheese]);
+  expect(chunk(camembert, 4, 1)).toEqual([fourCheese, fourCheese]);
+
+  // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
+  // each of these characters is five bytes
+  // (actually encodes to 13)
+  const womanRunningZWJ = '🏃‍♀️';
+  const womenRunningZWJ = `${womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
+  expect(chunk(womenRunningZWJ, 2, -1)).toEqual([
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+  expect(chunk(womenRunningZWJ, 2, 1)).toEqual([
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+});
+
+it('should count characters as bytes using chunkType value 0', () => {
+  // each of these characters is two bytes (actually encodes to 4)
+  const chineseTextA = '𤻪';
+  const chineseTextB = '𬜬';
+  const chineseTextC = '𬜯';
+  const chineseText = chineseTextA + chineseTextB + chineseTextC;
+  expect(chunk(chineseText, 2, 0)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 1, 0)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 11, 0)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 12, 0)).toEqual([
+    chineseTextA + chineseTextB + chineseTextC,
+  ]);
+
+  // each of these characters is two bytes (actually encodes to 4)
+  const twoCheese = '🧀🧀';
+  const camembert = `${twoCheese + twoCheese} ${twoCheese + twoCheese}`;
+  expect(chunk(camembert, 8, 0)).toEqual([
+    twoCheese,
+    twoCheese,
+    twoCheese,
+    twoCheese,
+  ]);
+
+  // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
+  // each of these characters is five bytes
+  // (actually encodes to 13)
+  const womanRunningZWJ = '🏃‍♀️';
+  const womenRunningZWJ = `${womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
+  expect(chunk(womenRunningZWJ, 26, 0)).toEqual([
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+  expect(
+    chunk(
+      `12123123 1231231 312312312 123 12 ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+      52,
+      0
+    )
+  ).toEqual([
+    `12123123 1231231 312312312 123 12 ${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}`,
+    `${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+  ]);
+
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  // (actually encodes to 17)
+  const runner = '🏃🏽‍♀️';
+  expect(chunk(runner + runner + runner, 17, 0)).toEqual([
+    runner,
+    runner,
+    runner,
+  ]);
+  expect(
+    chunk(
+      `12123123 1231231 312312312 123 12 ${runner}${runner}${runner}${runner}${runner}${runner} ${runner}${runner}${runner}${runner} ${runner} ${runner}${runner} ${runner}`,
+      68,
+      0
+    )
+  ).toEqual([
+    `12123123 1231231 312312312 123 12 ${runner}${runner}`,
+    `${runner}${runner}${runner}${runner}`,
+    `${runner}${runner}${runner}${runner}`,
+    `${runner} ${runner}${runner}`,
+    `${runner}`,
+  ]);
+});
+
+it('should count single width characters the same with all chunkType values', () => {
+  for (let i = 0; i < 100; i++) {
+    expect(chunk('hello you', 4, i)).toEqual(['hell', 'o', 'you']);
+  }
+});
+
+it('should count characters as bytes up to maximum N chunkType value > 0', () => {
+  // each of these characters is two bytes (actually encodes to 4)
+  const chineseTextA = '𤻪';
+  const chineseTextB = '𬜬';
+  const chineseTextC = '𬜯';
+  const chineseText = chineseTextA + chineseTextB + chineseTextC;
+  expect(chunk(chineseText, 2, 2)).toEqual([
+    chineseTextA,
+    chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 4, 2)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+  expect(chunk(chineseText, 2, 1)).toEqual([
+    chineseTextA + chineseTextB,
+    chineseTextC,
+  ]);
+
+  // each of these characters is two bytes (actually encodes to 4)
+  const cheese = '🧀';
+  const twoCheese = cheese + cheese;
+  const camembert = `${twoCheese + twoCheese} ${twoCheese + twoCheese}`;
+  expect(chunk(camembert, 4, 2)).toEqual([
+    twoCheese,
+    twoCheese,
+    twoCheese,
+    twoCheese,
+  ]);
+  expect(chunk(camembert, 4, 4)).toEqual([
+    cheese,
+    cheese,
+    cheese,
+    cheese,
+    cheese,
+    cheese,
+    cheese,
+    cheese,
+  ]);
+
+  // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
+  // each of these characters is five bytes
+  // (actually encodes to 13)
+  const womanRunningZWJ = '🏃‍♀️';
+  const womenRunningZWJ = `${womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
+  expect(chunk(womenRunningZWJ, 2, 0)).toEqual([
+    womanRunningZWJ,
+    womanRunningZWJ,
+    womanRunningZWJ,
+    womanRunningZWJ,
+    womanRunningZWJ,
+    womanRunningZWJ,
+  ]);
+  for (let i = 2; i < 100; i++) {
+    expect(chunk(womenRunningZWJ, 2, i)).toEqual([
+      womanRunningZWJ,
+      womanRunningZWJ,
+      womanRunningZWJ,
+      womanRunningZWJ,
+      womanRunningZWJ,
+      womanRunningZWJ,
+    ]);
+  }
+  expect(chunk(womenRunningZWJ, 4, 1)).toEqual([
+    womanRunningZWJ + womanRunningZWJ + womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+  expect(chunk(womenRunningZWJ, 4, 2)).toEqual([
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+  expect(chunk(womenRunningZWJ, 8, 4)).toEqual([
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+    womanRunningZWJ + womanRunningZWJ,
+  ]);
+  for (let i = 9; i < 100; i++) {
+    expect(chunk(womenRunningZWJ, 26, i)).toEqual([
+      womanRunningZWJ + womanRunningZWJ,
+      womanRunningZWJ + womanRunningZWJ,
+      womanRunningZWJ + womanRunningZWJ,
+    ]);
+  }
+  expect(
+    chunk(
+      `12123123 1231231 312312312 123 12 ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+      12,
+      2
+    )
+  ).toEqual([
+    '12123123',
+    '1231231',
+    '312312312',
+    '123 12',
+    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+  ]);
+
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  // (actually encodes to 17)
+  const runner = '🏃🏽‍♀️';
+  expect(chunk(runner + runner + runner, 4, 2)).toEqual([
+    runner + runner,
+    runner,
+  ]);
+  expect(
+    chunk(
+      `12123123 1231231 312312312 123 12 ${runner}${runner}${runner}${runner}${runner}${runner} ${runner}${runner}${runner}${runner} ${runner} ${runner}${runner} ${runner}`,
+      12,
+      2
+    )
+  ).toEqual([
+    '12123123',
+    '1231231',
+    '312312312',
+    '123 12',
+    `${runner}${runner}${runner}${runner}${runner}${runner}`,
+    `${runner}${runner}${runner}${runner} ${runner}`,
+    `${runner}${runner} ${runner}`,
+  ]);
+});
+
+it('should count N-byte characters with chunkType value 0 the same as chunkType value N', () => {
+  // each of these characters is two bytes (actually encodes to 4)
+  const camembert = '🧀🧀🧀🧀 🧀🧀🧀🧀';
+  expect(chunk(camembert, 4, 2)).toEqual(chunk(camembert, 8, 0));
+
+  // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
+  // each of these characters is five bytes
+  const womanRunningZWJ = '🏃‍♀️';
+  const womenRunningZWJ = `${womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
+  expect(chunk(womenRunningZWJ, 2, 0)).toEqual(chunk(womenRunningZWJ, 2, 5));
+
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  const runner = '🏃🏽‍♀️';
+  const runners = runner + runner + runner;
+  expect(chunk(runners, 2, 0)).toEqual(chunk(runners, 2, 7));
+});
+
+it('should count default chunkType the same as chunkType value -1', () => {
   // each of these characters is two bytes
   const chineseText = '𤻪𬜬𬜯';
-  const camembert = '🧀🧀🧀🧀 🧀🧀🧀🧀';
+  expect(chunk(chineseText, 2)).toEqual(chunk(chineseText, 2, -1));
+  expect(chunk(chineseText, 1)).toEqual(chunk(chineseText, 1, -1));
 
-  expect(chunk(chineseText, 2)).toEqual(['𤻪𬜬', '𬜯']);
-  expect(chunk(chineseText, 1)).toEqual(['𤻪', '𬜬', '𬜯']);
-  expect(chunk(camembert, 4)).toEqual(['🧀🧀🧀🧀', '🧀🧀🧀🧀']);
+  // each of these characters is two bytes
+  const camembert = '🧀🧀🧀🧀 🧀🧀🧀🧀';
+  expect(chunk(camembert, 4)).toEqual(chunk(camembert, 4, -1));
+
+  // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
+  // each of these characters is five bytes
+  const womanRunningZWJ = '🏃‍♀️';
+  const womenRunningZWJ = `${womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ +
+    womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
+  expect(chunk(womenRunningZWJ, 2)).toEqual(chunk(womenRunningZWJ, 2, -1));
+
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  const runner = '🏃🏽‍♀️';
+  const runners = runner + runner + runner;
+  expect(chunk(runners, 2)).toEqual(chunk(runners, 2, -1));
 });
 
 // this test does not pass yet

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,6 @@
 import chunk from '../index';
-import 'fast-text-encoding'; // Required for TextEncoder support in jest.
-
-it('should throw an error if no text is provided or invalid type.', () => {
+import { TextEncoder } from 'fastestsmallesttextencoderdecoder-encodeinto';
+it("should throw if 'text' is missing or its type or value are invalid.", () => {
   expect(() => {
     chunk();
   }).toThrow(
@@ -9,144 +8,167 @@ it('should throw an error if no text is provided or invalid type.', () => {
   );
 });
 
-it('should throw an error if no size is provided or invalid type.', () => {
+it("should throw if 'size' is missing or its type or value are invalid.", () => {
   expect(() => {
     chunk('hello world');
   }).toThrow(
     new TypeError(
-      'Size should be provided as 2nd argument and be a number greater than zero.'
+      'Size should be provided as 2nd argument and parseInt to a value greater than zero.'
     )
   );
   expect(() => {
     chunk('hello world', 0);
   }).toThrow(
     new TypeError(
-      'Size should be provided as 2nd argument and be a number greater than zero.'
+      'Size should be provided as 2nd argument and parseInt to a value greater than zero.'
     )
   );
 });
 
 it("should throw if 'type' argument's type or value is invalid.", () => {
   expect(() => {
-    chunk('hello world', 1, 'one');
+    chunk('hello world', 1, { charLengthMask: 'one' });
   }).toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, -2.001);
+    chunk('hello world', 1, { charLengthMask: -2.001 });
   }).toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, -2);
+    chunk('hello world', 1, { charLengthMask: -2 });
   }).toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, 3);
+    chunk('hello world', 1, { charLengthMask: 3 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, '3');
+    chunk('hello world', 1, { charLengthMask: '3' });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
 });
 
 it("should not throw if 'type' type and value are missing or valid.", () => {
   expect(() => {
-    chunk('hello world', 1, '');
-  }).not.toThrow(
+    chunk('hello world', 1, { charLengthMask: '' });
+  }).toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, null);
-  }).not.toThrow(
+    chunk('hello world', 1, { charLengthMask: null });
+  }).toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
-    chunk('hello world', 1, undefined);
+    chunk('hello world', 1, { charLengthMask: undefined });
+  }).toThrow(
+    new TypeError(
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, {});
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
+    )
+  );
+  expect(() => {
+    chunk('hello world', 1, { charLengthType: 'length' });
+  }).not.toThrow(
+    new TypeError(
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
     )
   );
   expect(() => {
     chunk('hello world', 1);
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, -1.999);
+    chunk('hello world', 1, { charLengthMask: -1.999 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, -0.001);
+    chunk('hello world', 1, { charLengthMask: -0.001 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, 0.0);
+    chunk('hello world', 1, { charLengthMask: 0.0 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, 1.0);
+    chunk('hello world', 1, { charLengthMask: 1.0 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, new Number.BigInt(2.0));
+    chunk('hello world', 1, { charLengthMask: new Number.BigInt(2.0) });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, 2.999);
+    chunk('hello world', 1, { charLengthMask: 2.999 });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, '2.99999 years');
+    chunk('hello world', 1, { charLengthMask: '2.99999 years' });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
   expect(() => {
-    chunk('hello world', 1, '2');
+    chunk('hello world', 1, { charLengthMask: '2' });
   }).not.toThrow(
     new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'TextEncoder']"
     )
   );
 });
@@ -195,26 +217,26 @@ it('should count multi-byte characters as single characters by default', () => {
   ).toEqual([runner + runner + runner, runner + runner + runner, runner]);
 });
 
-it('should count all characters as single characters using chunkType -1 or 1 values', () => {
+it('should count all characters as single characters using charLengthMask -1 or 1 values', () => {
   // each of these characters is two bytes
   const chineseTextA = '𤻪';
   const chineseTextB = '𬜬';
   const chineseTextC = '𬜯';
   const chineseText = chineseTextA + chineseTextB + chineseTextC;
-  expect(chunk(chineseText, 2, -1)).toEqual([
+  expect(chunk(chineseText, 2, { charLengthMask: -1 })).toEqual([
     chineseTextA + chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 1, -1)).toEqual([
+  expect(chunk(chineseText, 1, { charLengthMask: -1 })).toEqual([
     chineseTextA,
     chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 2, 1)).toEqual([
+  expect(chunk(chineseText, 2, { charLengthMask: 1 })).toEqual([
     chineseTextA + chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 1, 1)).toEqual([
+  expect(chunk(chineseText, 1, { charLengthMask: 1 })).toEqual([
     chineseTextA,
     chineseTextB,
     chineseTextC,
@@ -223,57 +245,62 @@ it('should count all characters as single characters using chunkType -1 or 1 val
   // each of these characters is two bytes
   const fourCheese = '🧀🧀🧀🧀';
   const camembert = `${fourCheese} ${fourCheese}`;
-  expect(chunk(camembert, 4, -1)).toEqual([fourCheese, fourCheese]);
-  expect(chunk(camembert, 4, 1)).toEqual([fourCheese, fourCheese]);
+  expect(chunk(camembert, 4, { charLengthMask: -1 })).toEqual([
+    fourCheese,
+    fourCheese,
+  ]);
+  expect(chunk(camembert, 4, { charLengthMask: 1 })).toEqual([
+    fourCheese,
+    fourCheese,
+  ]);
 
   // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
   // each of these characters is five bytes
-  // (actually encodes to 13)
   const womanRunningZWJ = '🏃‍♀️';
   const womenRunningZWJ = `${womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
-  expect(chunk(womenRunningZWJ, 2, -1)).toEqual([
+  expect(chunk(womenRunningZWJ, 2, { charLengthMask: -1 })).toEqual([
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
-  expect(chunk(womenRunningZWJ, 2, 1)).toEqual([
+  expect(chunk(womenRunningZWJ, 2, { charLengthMask: 1 })).toEqual([
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
 });
 
-it('should count characters as bytes using chunkType value 0', () => {
-  // each of these characters is two bytes (actually encodes to 4)
+it('should count characters as bytes using charLengthMask value 0', () => {
+  // each of these characters is two bytes
   const chineseTextA = '𤻪';
   const chineseTextB = '𬜬';
   const chineseTextC = '𬜯';
   const chineseText = chineseTextA + chineseTextB + chineseTextC;
-  expect(chunk(chineseText, 2, 0)).toEqual([
+  expect(chunk(chineseText, 2, { charLengthMask: 0 })).toEqual([
     chineseTextA,
     chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 1, 0)).toEqual([
+  expect(chunk(chineseText, 1, { charLengthMask: 0 })).toEqual([
     chineseTextA,
     chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 11, 0)).toEqual([
+  expect(chunk(chineseText, 4, { charLengthMask: 0 })).toEqual([
     chineseTextA + chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 12, 0)).toEqual([
+  expect(chunk(chineseText, 6, { charLengthMask: 0 })).toEqual([
     chineseTextA + chineseTextB + chineseTextC,
   ]);
 
-  // each of these characters is two bytes (actually encodes to 4)
+  // each of these characters is two bytes
   const twoCheese = '🧀🧀';
   const camembert = `${twoCheese + twoCheese} ${twoCheese + twoCheese}`;
-  expect(chunk(camembert, 8, 0)).toEqual([
+  expect(chunk(camembert, 4, { charLengthMask: 0 })).toEqual([
     twoCheese,
     twoCheese,
     twoCheese,
@@ -282,92 +309,92 @@ it('should count characters as bytes using chunkType value 0', () => {
 
   // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
   // each of these characters is five bytes
-  // (actually encodes to 13)
   const womanRunningZWJ = '🏃‍♀️';
   const womenRunningZWJ = `${womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
-  expect(chunk(womenRunningZWJ, 26, 0)).toEqual([
+  expect(chunk(womenRunningZWJ, 10, { charLengthMask: 0 })).toEqual([
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
   expect(
     chunk(
-      `12123123 1231231 312312312 123 12 ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
-      52,
-      0
+      `12123123 1231231 312312312 123 12 ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+      44,
+      { charLengthMask: 0 }
     )
   ).toEqual([
     `12123123 1231231 312312312 123 12 ${womanRunningZWJ}`,
-    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}`,
-    `${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}`,
-    `${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
-    `${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}`,
+    `${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
   ]);
 
   // one woman runner emoji with a colour is seven bytes, or five characters
   // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
-  // (actually encodes to 17)
   const runner = '🏃🏽‍♀️';
-  expect(chunk(runner + runner + runner, 17, 0)).toEqual([
-    runner,
-    runner,
+  expect(chunk(runner + runner + runner, 17, { charLengthMask: 0 })).toEqual([
+    runner + runner,
     runner,
   ]);
   expect(
     chunk(
-      `12123123 1231231 312312312 123 12 ${runner}${runner}${runner}${runner}${runner}${runner} ${runner}${runner}${runner}${runner} ${runner} ${runner}${runner} ${runner}`,
-      68,
-      0
+      `12123123 1231231 312312312 123 12 ${runner}${runner}${runner} ${runner}${runner}${runner} ${runner}${runner}${runner}${runner} ${runner} ${runner}${runner} ${runner}`,
+      28,
+      { charLengthMask: 0 }
     )
   ).toEqual([
-    `12123123 1231231 312312312 123 12 ${runner}${runner}`,
-    `${runner}${runner}${runner}${runner}`,
+    `12123123 1231231 312312312`,
+    `123 12 ${runner}${runner}${runner}`,
+    `${runner}${runner}${runner}`,
     `${runner}${runner}${runner}${runner}`,
     `${runner} ${runner}${runner}`,
     `${runner}`,
   ]);
 });
 
-it('should count single width characters the same with all chunkType values', () => {
+it('should count single width characters the same with all charLengthMask values', () => {
   for (let i = 0; i < 100; i++) {
-    expect(chunk('hello you', 4, i)).toEqual(['hell', 'o', 'you']);
+    expect(chunk('hello you', 4, { charLengthMask: i })).toEqual([
+      'hell',
+      'o',
+      'you',
+    ]);
   }
 });
 
-it('should count characters as bytes up to maximum N chunkType value > 0', () => {
-  // each of these characters is two bytes (actually encodes to 4)
+it('should count characters as bytes up to maximum N charLengthMask value > 0', () => {
+  // each of these characters is two bytes
   const chineseTextA = '𤻪';
   const chineseTextB = '𬜬';
   const chineseTextC = '𬜯';
   const chineseText = chineseTextA + chineseTextB + chineseTextC;
-  expect(chunk(chineseText, 2, 2)).toEqual([
+  expect(chunk(chineseText, 2, { charLengthMask: 2 })).toEqual([
     chineseTextA,
     chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 4, 2)).toEqual([
+  expect(chunk(chineseText, 4, { charLengthMask: 2 })).toEqual([
     chineseTextA + chineseTextB,
     chineseTextC,
   ]);
-  expect(chunk(chineseText, 2, 1)).toEqual([
+  expect(chunk(chineseText, 2, { charLengthMask: 1 })).toEqual([
     chineseTextA + chineseTextB,
     chineseTextC,
   ]);
 
-  // each of these characters is two bytes (actually encodes to 4)
+  // each of these characters is two bytes
   const cheese = '🧀';
   const twoCheese = cheese + cheese;
   const camembert = `${twoCheese + twoCheese} ${twoCheese + twoCheese}`;
-  expect(chunk(camembert, 4, 2)).toEqual([
+  expect(chunk(camembert, 4, { charLengthMask: 2 })).toEqual([
     twoCheese,
     twoCheese,
     twoCheese,
     twoCheese,
   ]);
-  expect(chunk(camembert, 4, 4)).toEqual([
+  expect(chunk(camembert, 2, { charLengthMask: 4 })).toEqual([
     cheese,
     cheese,
     cheese,
@@ -380,13 +407,12 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
 
   // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
   // each of these characters is five bytes
-  // (actually encodes to 13)
   const womanRunningZWJ = '🏃‍♀️';
   const womenRunningZWJ = `${womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
-  expect(chunk(womenRunningZWJ, 2, 0)).toEqual([
+  expect(chunk(womenRunningZWJ, 2, { charLengthMask: 0 })).toEqual([
     womanRunningZWJ,
     womanRunningZWJ,
     womanRunningZWJ,
@@ -395,7 +421,7 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
     womanRunningZWJ,
   ]);
   for (let i = 2; i < 100; i++) {
-    expect(chunk(womenRunningZWJ, 2, i)).toEqual([
+    expect(chunk(womenRunningZWJ, 2, { charLengthMask: i })).toEqual([
       womanRunningZWJ,
       womanRunningZWJ,
       womanRunningZWJ,
@@ -404,22 +430,22 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
       womanRunningZWJ,
     ]);
   }
-  expect(chunk(womenRunningZWJ, 4, 1)).toEqual([
+  expect(chunk(womenRunningZWJ, 4, { charLengthMask: 1 })).toEqual([
     womanRunningZWJ + womanRunningZWJ + womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
-  expect(chunk(womenRunningZWJ, 4, 2)).toEqual([
+  expect(chunk(womenRunningZWJ, 4, { charLengthMask: 2 })).toEqual([
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
-  expect(chunk(womenRunningZWJ, 8, 4)).toEqual([
+  expect(chunk(womenRunningZWJ, 8, { charLengthMask: 4 })).toEqual([
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
     womanRunningZWJ + womanRunningZWJ,
   ]);
   for (let i = 9; i < 100; i++) {
-    expect(chunk(womenRunningZWJ, 26, i)).toEqual([
+    expect(chunk(womenRunningZWJ, 11, { charLengthMask: i })).toEqual([
       womanRunningZWJ + womanRunningZWJ,
       womanRunningZWJ + womanRunningZWJ,
       womanRunningZWJ + womanRunningZWJ,
@@ -429,7 +455,7 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
     chunk(
       `12123123 1231231 312312312 123 12 ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ} ${womanRunningZWJ}${womanRunningZWJ} ${womanRunningZWJ}`,
       12,
-      2
+      { charLengthMask: 2 }
     )
   ).toEqual([
     '12123123',
@@ -443,9 +469,8 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
 
   // one woman runner emoji with a colour is seven bytes, or five characters
   // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
-  // (actually encodes to 17)
   const runner = '🏃🏽‍♀️';
-  expect(chunk(runner + runner + runner, 4, 2)).toEqual([
+  expect(chunk(runner + runner + runner, 4, { charLengthMask: 2 })).toEqual([
     runner + runner,
     runner,
   ]);
@@ -453,7 +478,7 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
     chunk(
       `12123123 1231231 312312312 123 12 ${runner}${runner}${runner}${runner}${runner}${runner} ${runner}${runner}${runner}${runner} ${runner} ${runner}${runner} ${runner}`,
       12,
-      2
+      { charLengthMask: 2 }
     )
   ).toEqual([
     '12123123',
@@ -466,10 +491,12 @@ it('should count characters as bytes up to maximum N chunkType value > 0', () =>
   ]);
 });
 
-it('should count N-byte characters with chunkType value 0 the same as chunkType value N', () => {
-  // each of these characters is two bytes (actually encodes to 4)
+it('should count N-byte characters with charLengthMask value 0 the same as charLengthMask value N', () => {
+  // each of these characters is two bytes
   const camembert = '🧀🧀🧀🧀 🧀🧀🧀🧀';
-  expect(chunk(camembert, 4, 2)).toEqual(chunk(camembert, 8, 0));
+  expect(chunk(camembert, 8, { charLengthMask: 2 })).toEqual(
+    chunk(camembert, 8, { charLengthMask: 0 })
+  );
 
   // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
   // each of these characters is five bytes
@@ -478,24 +505,34 @@ it('should count N-byte characters with chunkType value 0 the same as chunkType 
     womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
-  expect(chunk(womenRunningZWJ, 2, 0)).toEqual(chunk(womenRunningZWJ, 2, 5));
+  expect(chunk(womenRunningZWJ, 2, { charLengthMask: 0 })).toEqual(
+    chunk(womenRunningZWJ, 2, { charLengthMask: 5 })
+  );
 
   // one woman runner emoji with a colour is seven bytes, or five characters
   // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
   const runner = '🏃🏽‍♀️';
   const runners = runner + runner + runner;
-  expect(chunk(runners, 2, 0)).toEqual(chunk(runners, 2, 7));
+  expect(chunk(runners, 2, { charLengthMask: 0 })).toEqual(
+    chunk(runners, 2, { charLengthMask: 7 })
+  );
 });
 
-it('should count default chunkType the same as chunkType value -1', () => {
+it('should count default charLengthMask the same as charLengthMask value -1', () => {
   // each of these characters is two bytes
   const chineseText = '𤻪𬜬𬜯';
-  expect(chunk(chineseText, 2)).toEqual(chunk(chineseText, 2, -1));
-  expect(chunk(chineseText, 1)).toEqual(chunk(chineseText, 1, -1));
+  expect(chunk(chineseText, 2)).toEqual(
+    chunk(chineseText, 2, { charLengthMask: -1 })
+  );
+  expect(chunk(chineseText, 1)).toEqual(
+    chunk(chineseText, 1, { charLengthMask: -1 })
+  );
 
   // each of these characters is two bytes
   const camembert = '🧀🧀🧀🧀 🧀🧀🧀🧀';
-  expect(chunk(camembert, 4)).toEqual(chunk(camembert, 4, -1));
+  expect(chunk(camembert, 4)).toEqual(
+    chunk(camembert, 4, { charLengthMask: -1 })
+  );
 
   // The Woman Running emoji is a ZWJ sequence combining 🏃 Person Running, ‍ Zero Width Joiner and ♀ Female Sign.
   // each of these characters is five bytes
@@ -504,24 +541,75 @@ it('should count default chunkType the same as chunkType value -1', () => {
     womanRunningZWJ +
     womanRunningZWJ +
     womanRunningZWJ} ${womanRunningZWJ + womanRunningZWJ}`;
-  expect(chunk(womenRunningZWJ, 2)).toEqual(chunk(womenRunningZWJ, 2, -1));
+  expect(chunk(womenRunningZWJ, 2)).toEqual(
+    chunk(womenRunningZWJ, 2, { charLengthMask: -1 })
+  );
 
   // one woman runner emoji with a colour is seven bytes, or five characters
   // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
   const runner = '🏃🏽‍♀️';
   const runners = runner + runner + runner;
-  expect(chunk(runners, 2)).toEqual(chunk(runners, 2, -1));
+  expect(chunk(runners, 2)).toEqual(chunk(runners, 2, { charLengthMask: -1 }));
 });
 
-// this test does not pass yet
 it('should not cut combined characters', () => {
   // one woman runner emoji with a colour is seven bytes, or five characters
   // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
-  const runners = '🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️';
+  const runner = '🏃🏽‍♀️';
+  const runners = runner + runner + runner;
+  expect(chunk(runners, 3)).toEqual([runners]);
+  expect(chunk(runners, 1)).toEqual([runner, runner, runner]);
+
   // FLAG + RAINBOW
+  const flag = '🏳️‍🌈';
+  const flags = flag + flag;
+  expect(chunk(flags, 1)).toEqual([flag, flag]);
+});
+
+it('allows alternate TextEncoder', () => {
+  // one woman runner emoji with a colour is seven bytes, or five characters
+  // RUNNER(2) + COLOUR(2) + ZJW + GENDER + VS15
+  // 7 each as length, 17 each as TextEncoder
+  // 21 as length, 51 as TextEncoder
+  const runners = '🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️';
+
+  expect(() => {
+    chunk(runners, 14, { charLengthMask: 0, charLengthType: 'TextEncoder' });
+  }).toThrow(
+    new ReferenceError(
+      "TextEncoder is not natively defined, new TextEncoder must be passed in with the 'chunkOptions.textEncoder' property."
+    )
+  );
+
+  expect(
+    chunk(runners, 51, {
+      charLengthMask: 0,
+      charLengthType: 'TextEncoder',
+      textEncoder: new TextEncoder(),
+    })
+  ).toEqual(chunk(runners, 21, { charLengthMask: 0 }));
+
+  // FLAG + RAINBOW
+  // 2 each as length, 4 each as TextEncoder
+  // 4 as length, 8 as TextEncoder
+  // Node v14.5.0 does not provide TextEncoder natively.
   const flags = '🏳️‍🌈🏳️‍🌈';
 
-  expect(chunk(runners, 3)).toEqual(['🏃🏽‍♀️🏃🏽‍♀️🏃🏽‍♀️']);
-  expect(chunk(runners, 1)).toEqual(['🏃🏽‍♀️', '🏃🏽‍♀️', '🏃🏽‍♀️']);
-  expect(chunk(flags, 1)).toEqual(['🏳️‍🌈', '🏳️‍🌈']);
+  expect(
+    chunk(flags, 4, {
+      charLengthMask: 0,
+      charLengthType: 'TextEncoder',
+      textEncoder: new TextEncoder(),
+    })
+  ).toEqual(chunk(flags, 2, { charLengthMask: 0 }));
+
+  expect(
+    chunk(flags, 999, {
+      charLengthMask: 0,
+      charLengthType: 'TextEncoder',
+      textEncoder: {
+        encode: () => ({ length: 999 }),
+      },
+    })
+  ).toEqual(chunk(flags, 2, { charLengthMask: 0 }));
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,29 +12,67 @@ const assertIsValidText = function(text) {
 const assertIsValidChunkSize = function(chunkSize) {
   if (Number.isNaN(chunkSize) || Number.parseInt(chunkSize, 10) <= 0) {
     throw new TypeError(
-      'Size should be provided as 2nd argument and be a number greater than zero.'
+      'Size should be provided as 2nd argument and parseInt to a value greater than zero.'
     );
   }
 };
 
-const assertIsValidChunkType = function(
-  chunkType,
-  chunkTypeParseIntNaN,
-  chunkTypeInt
-) {
+const assertIsValidChunkOptions = function(chunkOptions) {
   if (
-    typeof chunkType !== 'undefined' &&
-    chunkType !== null &&
-    chunkType !== '' &&
-    (chunkTypeParseIntNaN || chunkTypeInt < -1)
+    typeof chunkOptions !== 'object' &&
+    typeof chunkOptions !== 'undefined' &&
+    chunkOptions !== null &&
+    chunkOptions !== ''
   ) {
     throw new TypeError(
-      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+      'Options should be provided as 3rd (optional) argument and be an object.\n' +
+        "Potential chunkOptions object properties include: ['charLengthMask', 'charLengthType', 'textEncoder']"
     );
   }
 };
 
-const chunkLength = function(characters, chunkType, textEncoder) {
+const assertIsValidCharLengthMask = function(
+  charLengthMask,
+  charLengthMaskIntParseIntNaN,
+  charLengthMaskInt
+) {
+  if (charLengthMaskIntParseIntNaN || charLengthMaskInt < -1) {
+    throw new TypeError(
+      'charLengthMask should be provided as a chunkOptions property and parseInt to a value >= -1.'
+    );
+  }
+};
+
+const assertIsValidTextEncoder = function(textEncoder) {
+  if (
+    typeof textEncoder === 'string' ||
+    Array.isArray(textEncoder) ||
+    typeof textEncoder === 'undefined' ||
+    textEncoder === null
+  ) {
+    throw new TypeError(
+      'textEncoder should be provided as a chunkOptions property and be an object containing the .encode(text).length property.'
+    );
+  }
+};
+
+const assertIsValidCharLengthType = function(charLengthType) {
+  if (
+    typeof charLengthType !== 'string' ||
+    !(charLengthType === 'length' || charLengthType === 'TextEncoder')
+  ) {
+    throw new TypeError(
+      "charLengthType should be provided as a chunkOptions property and be a value in ['length', 'TextEncoder']"
+    );
+  }
+};
+
+const chunkLength = function(
+  characters,
+  charLengthMask,
+  charLengthType,
+  textEncoder
+) {
   let length;
   if (
     typeof characters === 'undefined' ||
@@ -56,18 +94,29 @@ const chunkLength = function(characters, chunkType, textEncoder) {
       charactersArray === null
     ) {
       length = -1;
-    } else if (chunkType === 0) {
+    } else if (charLengthMask === 0) {
       length = charactersArray
-        .map(character => textEncoder.encode(character).length)
+        .map(
+          character =>
+            (charLengthType === 'TextEncoder'
+              ? textEncoder.encode(character)
+              : character).length
+        )
         .reduce((accumulator, currentValue) => accumulator + currentValue);
-    } else if (chunkType > 0) {
+    } else if (charLengthMask > 0) {
       const arrayLength = charactersArray
-        .map(character => textEncoder.encode(character).length)
+        .map(
+          character =>
+            (charLengthType === 'TextEncoder'
+              ? textEncoder.encode(character)
+              : character).length
+        )
         .reduce(
           (accumulator, currentValue) =>
-            accumulator + (currentValue > chunkType ? chunkType : currentValue)
+            accumulator +
+            (currentValue > charLengthMask ? charLengthMask : currentValue)
         );
-      const maxLength = charactersArray.length * chunkType;
+      const maxLength = charactersArray.length * charLengthMask;
       length = maxLength > arrayLength ? arrayLength : maxLength;
     } else {
       length = charactersArray.length;
@@ -75,22 +124,39 @@ const chunkLength = function(characters, chunkType, textEncoder) {
   }
   return length;
 };
+const lastSpaceOrLength = (text, upTo) => {
+  let lastIndex = text.lastIndexOf(' ', upTo);
+  if (lastIndex === -1) {
+    lastIndex = upTo;
+  }
+  if (lastIndex > text.length || upTo >= text.length) {
+    lastIndex = text.length;
+  }
+  return lastIndex;
+};
 
-const chunkIndexOf = function(characters, chunkSize, chunkType, textEncoder) {
-  let splitAt = characters.lastIndexOf(' ', chunkSize);
-  if (splitAt > -2 && splitAt < 1) {
-    splitAt = chunkSize;
-  }
-  if (splitAt > characters.length || chunkSize >= characters.length) {
-    splitAt = characters.length;
-  }
+const chunkIndexOf = function(
+  characters,
+  chunkSize,
+  charLengthMask,
+  charLengthType,
+  textEncoder
+) {
+  let splitAt = lastSpaceOrLength(characters, chunkSize);
+
   while (
     splitAt > 0 &&
     chunkSize <
-      chunkLength(characters.slice(0, splitAt), chunkType, textEncoder)
+      chunkLength(
+        characters.slice(0, splitAt),
+        charLengthMask,
+        charLengthType,
+        textEncoder
+      )
   ) {
     splitAt = splitAt - 1;
   }
+  splitAt = lastSpaceOrLength(characters, splitAt);
   if ((splitAt > -2 && splitAt < 1) || characters[splitAt] === ' ') {
     splitAt = splitAt + 1;
   }
@@ -104,22 +170,69 @@ const chunkIndexOf = function(characters, chunkSize, chunkType, textEncoder) {
   return splitAt;
 };
 
-export default function(text, chunkSize, chunkType) {
+export default function(text, chunkSize, chunkOptions) {
   assertIsValidText(text);
   const chunkSizeInt = Number.parseInt(chunkSize, 10);
   assertIsValidChunkSize(chunkSizeInt);
-  const chunkTypeParseInt = Number.parseInt(chunkType, 10);
-  const chunkTypeParseIntNaN = Number.isNaN(chunkTypeParseInt);
-  assertIsValidChunkType(chunkType, chunkTypeParseIntNaN, chunkTypeParseInt);
-  const chunkTypeInt = chunkTypeParseIntNaN ? -1 : chunkTypeParseInt;
+  assertIsValidChunkOptions(chunkOptions);
+
+  let charLengthMaskInt = -1;
+  let charLengthMaskIntParseInt = -1;
+  let charLengthMaskIntParseIntNaN = true;
+  let textEncoderObject;
+  if (typeof chunkOptions === 'object') {
+    if (Object.prototype.hasOwnProperty.call(chunkOptions, 'charLengthMask')) {
+      charLengthMaskInt = chunkOptions.charLengthMask;
+      charLengthMaskIntParseInt = Number.parseInt(charLengthMaskInt, 10);
+      charLengthMaskIntParseIntNaN = Number.isNaN(charLengthMaskIntParseInt);
+      assertIsValidCharLengthMask(
+        charLengthMaskInt,
+        charLengthMaskIntParseIntNaN,
+        charLengthMaskIntParseInt
+      );
+    }
+    if (Object.prototype.hasOwnProperty.call(chunkOptions, 'charLengthType')) {
+      assertIsValidCharLengthType(chunkOptions.charLengthType);
+      if (chunkOptions.charLengthType === 'TextEncoder') {
+        if (Object.prototype.hasOwnProperty.call(chunkOptions, 'textEncoder')) {
+          assertIsValidTextEncoder(chunkOptions.textEncoder);
+          textEncoderObject = chunkOptions.textEncoder;
+        }
+      }
+    }
+  }
+  const charLengthMask = charLengthMaskIntParseIntNaN
+    ? -1
+    : charLengthMaskIntParseInt;
+  const charLengthType = typeof chunkOptions === 'object' &&
+    chunkOptions.charLengthType
+    ? chunkOptions.charLengthType
+    : 'length';
+  try {
+    if (
+      charLengthType === 'TextEncoder' &&
+      (typeof textEncoderObject === 'undefined' ||
+        textEncoderObject === null ||
+        textEncoderObject === '')
+    ) {
+      textEncoderObject = new TextEncoder();
+    }
+  } catch (ex) {
+    throw new ReferenceError(
+      "TextEncoder is not natively defined, new TextEncoder must be passed in with the 'chunkOptions.textEncoder' property."
+    );
+  }
+  const textEncoder = textEncoderObject;
   const chunks = [];
   let characters = runes(text);
-  const textEncoder = new TextEncoder();
-  while (chunkLength(characters, chunkTypeInt, textEncoder) > 0) {
+  while (
+    chunkLength(characters, charLengthMask, charLengthType, textEncoder) > 0
+  ) {
     const splitAt = chunkIndexOf(
       characters,
       chunkSizeInt,
-      chunkTypeInt,
+      charLengthMask,
+      charLengthType,
       textEncoder
     );
     const chunk = characters.slice(0, splitAt).join('').trim();

--- a/src/index.js
+++ b/src/index.js
@@ -10,36 +10,116 @@ const assertIsValidText = function(text) {
 };
 
 const assertIsValidChunkSize = function(chunkSize) {
-  if (typeof chunkSize !== 'number' || chunkSize <= 0) {
+  if (Number.isNaN(chunkSize) || Number.parseInt(chunkSize, 10) <= 0) {
     throw new TypeError(
       'Size should be provided as 2nd argument and be a number greater than zero.'
     );
   }
 };
 
-export default function(text, chunkSize) {
-  assertIsValidText(text);
-  assertIsValidChunkSize(chunkSize);
+const assertIsValidChunkType = function(
+  chunkType,
+  chunkTypeParseIntNaN,
+  chunkTypeInt
+) {
+  if (
+    typeof chunkType !== 'undefined' &&
+    chunkType !== null &&
+    chunkType !== '' &&
+    (chunkTypeParseIntNaN || chunkTypeInt < -1)
+  ) {
+    throw new TypeError(
+      'Type should be provided as 3rd (optional) argument and parseInt to a value >= -1.'
+    );
+  }
+};
 
-  const chunks = [];
-  let characters = runes(text);
+const chunkLength = function(characters, chunkType) {
+  let length;
+  if (
+    typeof characters === 'undefined' ||
+    characters === null ||
+    characters === ''
+  ) {
+    length = -1;
+  } else {
+    let charactersArray;
+    if (typeof characters === 'string') {
+      charactersArray = [characters];
+    } else if (Array.isArray(characters) && characters.length) {
+      charactersArray = characters;
+    }
 
-  while (characters.length > chunkSize) {
-    const splitAt = characters.lastIndexOf(' ', chunkSize);
-
-    if (splitAt === -1) {
-      // No whitespace found, we need to truncate the word in that case.
-      const chunk = characters.slice(0, chunkSize).join('');
-      chunks.push(chunk);
-      characters = characters.slice(chunkSize); // eslint-disable-line no-param-reassign
+    if (
+      !Array.isArray(charactersArray) ||
+      !charactersArray.length ||
+      charactersArray === null
+    ) {
+      length = -1;
+    } else if (chunkType === 0) {
+      length = charactersArray
+        .map(character => new TextEncoder().encode(character).length)
+        .reduce((accumulator, currentValue) => accumulator + currentValue);
+    } else if (chunkType > 0) {
+      const arrayLength = charactersArray
+        .map(character => new TextEncoder().encode(character).length)
+        .reduce(
+          (accumulator, currentValue) =>
+            accumulator + (currentValue > chunkType ? chunkType : currentValue)
+        );
+      const maxLength = charactersArray.length * chunkType;
+      length = maxLength > arrayLength ? arrayLength : maxLength;
     } else {
-      const chunk = characters.slice(0, splitAt).join('');
-      chunks.push(chunk);
-      characters = characters.slice(splitAt + 1); // eslint-disable-line no-param-reassign
+      length = charactersArray.length;
     }
   }
+  return length;
+};
 
-  chunks.push(characters.join(''));
+const chunkIndexOf = function(characters, chunkSize, chunkType) {
+  let splitAt = characters.lastIndexOf(' ', chunkSize);
+  if (splitAt > -2 && splitAt < 1) {
+    splitAt = chunkSize;
+  }
+  if (splitAt > characters.length || chunkSize >= characters.length) {
+    splitAt = characters.length;
+  }
+  while (
+    splitAt > 0 &&
+    chunkSize < chunkLength(characters.slice(0, splitAt), chunkType)
+  ) {
+    splitAt = splitAt - 1;
+  }
+  if ((splitAt > -2 && splitAt < 1) || characters[splitAt] === ' ') {
+    splitAt = splitAt + 1;
+  }
+  if (
+    splitAt > characters.length ||
+    splitAt < 0 ||
+    (splitAt === 0 && characters.length === 1)
+  ) {
+    splitAt = characters.length;
+  }
+  return splitAt;
+};
 
+export default function(text, chunkSize, chunkType) {
+  assertIsValidText(text);
+  const chunkSizeInt = Number.parseInt(chunkSize, 10);
+  assertIsValidChunkSize(chunkSizeInt);
+  const chunkTypeParseInt = Number.parseInt(chunkType, 10);
+  const chunkTypeParseIntNaN = Number.isNaN(chunkTypeParseInt);
+  assertIsValidChunkType(chunkType, chunkTypeParseIntNaN, chunkTypeParseInt);
+  const chunkTypeInt = chunkTypeParseIntNaN ? -1 : chunkTypeParseInt;
+  const chunks = [];
+  let characters = runes(text);
+  while (chunkLength(characters, chunkTypeInt) > 0) {
+    const splitAt = chunkIndexOf(characters, chunkSizeInt, chunkTypeInt);
+    const chunk = characters.slice(0, splitAt).join('').trim();
+    if (chunk !== '' && chunk !== null) {
+      chunks.push(chunk);
+    }
+    characters = characters.slice(splitAt);
+  }
   return chunks;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const assertIsValidChunkType = function(
   }
 };
 
-const chunkLength = function(characters, chunkType) {
+const chunkLength = function(characters, chunkType, textEncoder) {
   let length;
   if (
     typeof characters === 'undefined' ||
@@ -58,11 +58,11 @@ const chunkLength = function(characters, chunkType) {
       length = -1;
     } else if (chunkType === 0) {
       length = charactersArray
-        .map(character => new TextEncoder().encode(character).length)
+        .map(character => textEncoder.encode(character).length)
         .reduce((accumulator, currentValue) => accumulator + currentValue);
     } else if (chunkType > 0) {
       const arrayLength = charactersArray
-        .map(character => new TextEncoder().encode(character).length)
+        .map(character => textEncoder.encode(character).length)
         .reduce(
           (accumulator, currentValue) =>
             accumulator + (currentValue > chunkType ? chunkType : currentValue)
@@ -76,7 +76,7 @@ const chunkLength = function(characters, chunkType) {
   return length;
 };
 
-const chunkIndexOf = function(characters, chunkSize, chunkType) {
+const chunkIndexOf = function(characters, chunkSize, chunkType, textEncoder) {
   let splitAt = characters.lastIndexOf(' ', chunkSize);
   if (splitAt > -2 && splitAt < 1) {
     splitAt = chunkSize;
@@ -86,7 +86,8 @@ const chunkIndexOf = function(characters, chunkSize, chunkType) {
   }
   while (
     splitAt > 0 &&
-    chunkSize < chunkLength(characters.slice(0, splitAt), chunkType)
+    chunkSize <
+      chunkLength(characters.slice(0, splitAt), chunkType, textEncoder)
   ) {
     splitAt = splitAt - 1;
   }
@@ -113,8 +114,14 @@ export default function(text, chunkSize, chunkType) {
   const chunkTypeInt = chunkTypeParseIntNaN ? -1 : chunkTypeParseInt;
   const chunks = [];
   let characters = runes(text);
-  while (chunkLength(characters, chunkTypeInt) > 0) {
-    const splitAt = chunkIndexOf(characters, chunkSizeInt, chunkTypeInt);
+  const textEncoder = new TextEncoder();
+  while (chunkLength(characters, chunkTypeInt, textEncoder) > 0) {
+    const splitAt = chunkIndexOf(
+      characters,
+      chunkSizeInt,
+      chunkTypeInt,
+      textEncoder
+    );
     const chunk = characters.slice(0, splitAt).join('').trim();
     if (chunk !== '' && chunk !== null) {
       chunks.push(chunk);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,6 +1287,11 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-text-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
+  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
+
 fb-watchman@^1.8.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,6 +1292,11 @@ fast-text-encoding@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
   integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
 
+fastestsmallesttextencoderdecoder-encodeinto@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder-encodeinto/-/fastestsmallesttextencoderdecoder-encodeinto-1.0.22.tgz#c095cf0f54ff93f7028dec8c7be546ea48edeffe"
+  integrity sha512-csOz3cwJjZY75QcPHnY+v6cKWeofYCmhtLVYaurjcRn5vaNXoYe1Leo1ZkiZIxZp796+J5Z+TtmeMbbfYBfiiQ==
+
 fb-watchman@^1.8.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,11 +1287,6 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fast-text-encoding@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
-  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
-
 fastestsmallesttextencoderdecoder-encodeinto@^1.0.22:
   version "1.0.22"
   resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder-encodeinto/-/fastestsmallesttextencoderdecoder-encodeinto-1.0.22.tgz#c095cf0f54ff93f7028dec8c7be546ea48edeffe"


### PR DESCRIPTION
- Add chunkType parameter, allowing multi-byte aware chunking.
   - Third parameter, default behavior if excluded is equal to previous behavior.
   - "-1"  : same as previous default behaviour. every character = 1
   - "0"   : every character = as many bytes as the character is
   - ">0" : every character = as many bytes as the character is, up to N
     - This is the use case I need, as I need each emoji to count as "2".
- Some characters may encode to more bytes than one might have expected.
- Added new tests to accommodate changes and verify backwards compatibility.
     - When working with emoji, I've had issues where they display differently everywhere.
     - Parsing the variable names has been easier overall, while sometimes more annoying on properly encoding editors.
- Changed chunkSize validation to use Numbers.parseInt and Numbers.isNaN
  - It has better overall compatibility, though does allow weird things like `chunk("text", "2 years", "-1 years")`
- Updated dependencies.
   - Added `fast-text-encoding` in order to fill `TextEncoder` in `jest`
- Incremented minor version, because although adding a parameter isn't a breaking change --
   - I do worry the overall changes may have some possibility of compatibility issue. Babel helps alleviate this concern though.
   - The effort to allow this capability has increased the complexity of this project.
      - I've tried to add enough testing to mitigate for the risks this presents.