### PR TITLE
HOTFIX: allow dist for npm builds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+npm-debug.log
+coverage/
+package-lock.json


### PR DESCRIPTION
my build updated to use the dist build folder
the script calls yarn build
but .gitignore applies when .npmignore is not there
i already had dist/ built in my tests
this resolves